### PR TITLE
makes sms code random and links account signup to idv

### DIFF
--- a/_includes/toolbox.html
+++ b/_includes/toolbox.html
@@ -8,7 +8,16 @@
       <i class="block fa fa-envelope-o" aria-hidden="true" style="font-size:24px;"></i>
       <span class="block">Email</span>
     </a>
-    <a class="block silver py2 border-bottom h5 relative{% if page.sms_indicator == true %} hint--right hint--always hint--rounded hint--info{% endif %}" href="#" aria-label="577123 is your login.gov one-time passcode."{% if page.sms_indicator != true %} onclick="alert('No new text messages!');"{% endif %}>
+    <a class="block silver py2 border-bottom h5 relative{% if page.sms_indicator == true %} hint--right hint--always hint--rounded hint--info{% endif %}"
+        href="#"
+        aria-label="{% assign min = 111111 %}
+                    {% assign max = 999999 %}
+                    {% assign diff = max | minus: min %}
+                    {% assign randomNumber = "now" | date: "%N" | modulo: diff | plus: min %}
+                    {{ randomNumber }} is your login.gov one-time passcode."
+        {% if page.sms_indicator != true %}
+          onclick="alert('No new text messages!');"
+        {% endif %}>
       {% if page.sms_indicator == true %}
         <div class="bg-red circle center overflow-hidden toolbox-indicator absolute bold h6">1</div>
       {% endif %}

--- a/_pages/create/16-recovery-code.html
+++ b/_pages/create/16-recovery-code.html
@@ -30,7 +30,7 @@ permalink: /settings/recovery-code/
       <div class="right mt1"><img width="96" class="align-middle mt-tiny" src="/images/logo.svg" alt="Logo">
       </div>
     </div>
-    <form class="button_to" action="{{ "/success_idv/" | prepend: site.baseurl }}">
+    <form class="button_to" action="{{ "/idv/" | prepend: site.baseurl }}">
       <input class="btn btn-primary btn-wide mb1" type="submit" value="Continue">
     </form>
   </div>


### PR DESCRIPTION
This randomizes the SMS code that appears when you hit screens that utilize the toolbox.

Also links the regular account signup to the identity verification process so you can go through from account creation to IDV and see the two steps where you have to put in a code. 