### PR TITLE
Fix broken URLs, condense two pages into one

### DIFF
--- a/_pages/idv/09-checking.html
+++ b/_pages/idv/09-checking.html
@@ -7,16 +7,16 @@ permalink: /idv/checking/
 <div class="container sm-pt3">
   <div class="px2 py3 sm-py5 sm-px6 mx-auto mb6 border-box card">
     <form autocomplete="off" role="form" class="simple_form new_profile" id="new_profile" action="{{ "/idv/info_verified/" | prepend: site.baseurl }}" accept-charset="UTF-8">
-      <h1 class="h3 my0">
+      <h1 class="h3 my0 pt1">
         Checking personal information…
       </h1>
-        <div class="mt5 mb5">
+        <div class="pt2 mt5 mb5">
           <img alt="images" class="block mx-auto pt4 pb4" width="72" src="{{ "/images/spinner-v1-144.gif" | prepend: site.baseurl }}">
         </div>
-      <div class="pt2">
+      <!-- <div class="pt2">
         <button class="block mx-auto btn btn-primary btn-wide" type="submit">Continue</button>
       </div>
-        <!-- {% include cancel-identity.html %} -->
+      {% include cancel-identity.html %} -->
       </form>
   </div>
 </div>

--- a/_pages/idv/10-info_verified.html
+++ b/_pages/idv/10-info_verified.html
@@ -6,10 +6,17 @@ permalink: /idv/info_verified/
 
 <div class="container sm-pt3">
   <div class="px2 py3 sm-py5 sm-px6 mx-auto sm-mb5 border-box card">
-    <form autocomplete="off" role="form" class="simple_form new_profile" id="new_profile" action="{{ "/idv/address_confirm" | prepend: site.baseurl }}" accept-charset="UTF-8">
+    <form autocomplete="off" role="form" class="simple_form new_profile" id="new_profile" action="{{ "/address/" | prepend: site.baseurl }}" accept-charset="UTF-8">
       <img alt="images" class="mb2" width="200" src="{{ "/images/ID-confirm@3x.png" | prepend: site.baseurl }}">
-      <h1 class="h3 mt2 mb6 pb6">
+      <h1 class="h3 mt2 mb3">
         Your personal information has been verified.
+      </h1>
+      <div class="pb-tiny bg-green col-2">
+
+      </div>
+
+      <h1 class="h3 mt3 mb4">
+        Next, we need to confirm your address by sending you an address confirmation code.
       </h1>
 
         <button class="btn btn-primary btn-wide" type="submit">Continue</button>


### PR DESCRIPTION
the page that auto-advanced was returning a 404, and I condensed two pages into one (fewer clicks).

There were the original two pages:
![image](https://user-images.githubusercontent.com/12564977/39767416-56bdd0aa-52ac-11e8-823d-dbda13dd7745.png)

and this is the condensed version:
![image](https://user-images.githubusercontent.com/12564977/39767441-67708e24-52ac-11e8-978f-72eec1c62ba6.png)
